### PR TITLE
Fix editor loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ export ROAMER_EDITOR=emacs
 
 If no editor is set then vi will be used.
 
+[Works with any editor?](doc/faq.md#any-text-editor)
+
 #### Data Directory
 Roamer needs a directory for storing data between sessions.  By default this will be saved in `.roamer-data` in your home directory.
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -23,3 +23,18 @@ source ~/.bashrc
 echo "export PATH=\$PATH:~/.local/bin" >> ~/.zshrc
 source ~/.zshrc
 ```
+
+### Any Text Editor?
+
+Roamer should work with any text editor that blocks.  That is any editor that lets you write messages with `git commit`.    ( e.g. Atom's `--wait` flag )
+
+Tested Editors:
+
+* vi
+* nano
+* vim
+* emacs
+* neovim
+* atom
+* sublime text 3
+* vscode

--- a/roamer/file_edit.py
+++ b/roamer/file_edit.py
@@ -16,11 +16,20 @@ else:
     if not EDITOR:
         EDITOR = 'vi'
 
-if EDITOR in ['vim', 'nvim', 'vi']:
-    EXTRA_EDITOR_COMMAND = '+set backupcopy=yes'
-else:
-    # nano and emacs work without any extra commands
+if ' ' in EDITOR:
     EXTRA_EDITOR_COMMAND = None
+else:
+    if os.path.basename(EDITOR) in ['vim', 'nvim', 'vi']:
+        EXTRA_EDITOR_COMMAND = '+set backupcopy=yes'
+    elif os.path.basename(EDITOR) == 'atom':
+        EXTRA_EDITOR_COMMAND = '--wait'
+    elif os.path.basename(EDITOR) == 'subl':
+        EXTRA_EDITOR_COMMAND = '-n -w'
+    elif os.path.basename(EDITOR) == 'mate':
+        EXTRA_EDITOR_COMMAND = '-w'
+    else:
+        # nano and emacs work without any extra commands
+        EXTRA_EDITOR_COMMAND = None
 
 
 def file_editor(content):
@@ -32,7 +41,7 @@ def file_editor(content):
         if EXTRA_EDITOR_COMMAND:
             call([EDITOR, EXTRA_EDITOR_COMMAND, temp.name])
         else:
-            call([EDITOR, temp.name])
+            call(EDITOR.split() + [temp.name])
         temp.seek(0)
         output = temp.read()
         if sys.version_info[0] == 3:

--- a/roamer/file_edit.py
+++ b/roamer/file_edit.py
@@ -19,14 +19,12 @@ else:
 if ' ' in EDITOR:
     EXTRA_EDITOR_COMMAND = None
 else:
-    if os.path.basename(EDITOR) in ['vim', 'nvim', 'vi']:
+    if os.path.basename(EDITOR) in ('vim', 'nvim', 'vi'):
         EXTRA_EDITOR_COMMAND = '+set backupcopy=yes'
-    elif os.path.basename(EDITOR) == 'atom':
-        EXTRA_EDITOR_COMMAND = '--wait'
+    elif os.path.basename(EDITOR) in ('atom', 'code', 'mate'):
+        EXTRA_EDITOR_COMMAND = '-w'
     elif os.path.basename(EDITOR) == 'subl':
         EXTRA_EDITOR_COMMAND = '-n -w'
-    elif os.path.basename(EDITOR) == 'mate':
-        EXTRA_EDITOR_COMMAND = '-w'
     else:
         # nano and emacs work without any extra commands
         EXTRA_EDITOR_COMMAND = None

--- a/roamer/file_edit.py
+++ b/roamer/file_edit.py
@@ -39,9 +39,11 @@ def file_editor(content):
         temp.write(content)
         temp.flush()
         if EXTRA_EDITOR_COMMAND:
-            call([EDITOR, EXTRA_EDITOR_COMMAND, temp.name])
+            exit_code = call([EDITOR, EXTRA_EDITOR_COMMAND, temp.name])
         else:
-            call(EDITOR.split() + [temp.name])
+            exit_code = call(EDITOR.split() + [temp.name])
+        if exit_code != 0:
+            sys.exit()
         temp.seek(0)
         output = temp.read()
         if sys.version_info[0] == 3:


### PR DESCRIPTION
* Properly handle flags set in EDITOR variables
* Set default flags for atom, sublime and vscode
* Use base path when determining default flags
* Closes #23  Closes #13