### PR TITLE
Confirmation (add safety)

### DIFF
--- a/roamer/main.py
+++ b/roamer/main.py
@@ -13,6 +13,6 @@ def start(argv):
         version = pkg_resources.require('roamer')[0].version
         print(version)
         return
-    if '--skipapproval' in argv:
+    if '--skip-approval' in argv:
         skipapproval = True
     Session(skipapproval=skipapproval).run()

--- a/roamer/main.py
+++ b/roamer/main.py
@@ -8,8 +8,11 @@ import pkg_resources
 from roamer.session import Session
 
 def start(argv):
+    skipapproval = False
     if '--version' in argv:
         version = pkg_resources.require('roamer')[0].version
         print(version)
         return
-    Session().run()
+    if '--skipapproval' in argv:
+        skipapproval = True
+    Session(skipapproval=skipapproval).run()

--- a/roamer/session.py
+++ b/roamer/session.py
@@ -33,5 +33,9 @@ class Session(object):
         engine = Engine(self.directory, self.edit_directory)
         engine.compile_commands()
         print(engine.commands_to_str())
+        answer = input('Please indicate approval: [y/n] ')
+        if not answer or answer[0].lower() != 'y':
+            print('You did not indicate approval')
+            exit(1)
         engine.run_commands()
         record.add_dir(Directory(self.cwd, os.listdir(self.cwd)))

--- a/roamer/session.py
+++ b/roamer/session.py
@@ -14,8 +14,9 @@ from roamer import record
 from roamer.database import db_init
 
 class Session(object):
-    def __init__(self, cwd=None):
+    def __init__(self, cwd=None, skipapproval=True):
         self.cwd = cwd
+        self.skipapproval = skipapproval
         if cwd is None:
             self.cwd = os.getcwd()
         db_init()
@@ -33,7 +34,9 @@ class Session(object):
         engine = Engine(self.directory, self.edit_directory)
         engine.compile_commands()
         print(engine.commands_to_str())
-        answer = input('Please indicate approval: [y/n] ')
+        answer = 'y'
+        if not self.skipapproval:
+            answer = input('Please indicate approval: [y/n] ')
         if not answer or answer[0].lower() != 'y':
             print('You did not indicate approval')
             exit(1)

--- a/roamer/session.py
+++ b/roamer/session.py
@@ -13,6 +13,11 @@ from roamer.engine import Engine
 from roamer import record
 from roamer.database import db_init
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
 class Session(object):
     def __init__(self, cwd=None, skipapproval=True):
         self.cwd = cwd
@@ -34,21 +39,19 @@ class Session(object):
         engine = Engine(self.directory, self.edit_directory)
         engine.compile_commands()
         print(engine.commands_to_str())
-        if engine.commands:
-            answer = 'y'
-            if not self.skipapproval:
-                print(
-                    'Argument --skip-approval could be used to run roamer '
-                    'in a noninteractive mode.'
-                )
-                try:
-                    answer = input('Please indicate approval: [y/N] ')
-                except KeyboardInterrupt:
-                    # Add line feed
-                    print()
-                    answer = None
-                if not answer or answer[0].lower() != 'y':
-                    print('You did not indicate approval.')
-                    exit(1)
+        if engine.commands and not self.skipapproval:
+            print(
+                'Argument --skip-approval could be used to run roamer '
+                'in a noninteractive mode.'
+            )
+            try:
+                answer = input('Please indicate approval: [y/N] ')
+            except KeyboardInterrupt:
+                # Add line feed
+                print()
+                answer = None
+            if not answer or answer[0].lower() != 'y':
+                print('You did not indicate approval.')
+                exit(1)
         engine.run_commands()
         record.add_dir(Directory(self.cwd, os.listdir(self.cwd)))

--- a/roamer/session.py
+++ b/roamer/session.py
@@ -41,9 +41,14 @@ class Session(object):
                     'Argument --skip-approval could be used to run roamer '
                     'in a noninteractive mode.'
                 )
-                answer = input('Please indicate approval: [y/N] ')
-            if not answer or answer[0].lower() != 'y':
-                print('You did not indicate approval.')
-                exit(1)
+                try:
+                    answer = input('Please indicate approval: [y/N] ')
+                except KeyboardInterrupt:
+                    # Add line feed
+                    print()
+                    answer = None
+                if not answer or answer[0].lower() != 'y':
+                    print('You did not indicate approval.')
+                    exit(1)
         engine.run_commands()
         record.add_dir(Directory(self.cwd, os.listdir(self.cwd)))

--- a/roamer/session.py
+++ b/roamer/session.py
@@ -34,11 +34,16 @@ class Session(object):
         engine = Engine(self.directory, self.edit_directory)
         engine.compile_commands()
         print(engine.commands_to_str())
-        answer = 'y'
-        if not self.skipapproval:
-            answer = input('Please indicate approval: [y/N] ')
-        if not answer or answer[0].lower() != 'y':
-            print('You did not indicate approval')
-            exit(1)
+        if engine.commands:
+            answer = 'y'
+            if not self.skipapproval:
+                print(
+                    'Argument --skip-approval could be used to run roamer '
+                    'in a noninteractive mode.'
+                )
+                answer = input('Please indicate approval: [y/N] ')
+            if not answer or answer[0].lower() != 'y':
+                print('You did not indicate approval.')
+                exit(1)
         engine.run_commands()
         record.add_dir(Directory(self.cwd, os.listdir(self.cwd)))

--- a/roamer/session.py
+++ b/roamer/session.py
@@ -36,7 +36,7 @@ class Session(object):
         print(engine.commands_to_str())
         answer = 'y'
         if not self.skipapproval:
-            answer = input('Please indicate approval: [y/n] ')
+            answer = input('Please indicate approval: [y/N] ')
         if not answer or answer[0].lower() != 'y':
             print('You did not indicate approval')
             exit(1)

--- a/roamer/session.py
+++ b/roamer/session.py
@@ -14,7 +14,7 @@ from roamer import record
 from roamer.database import db_init
 
 try:
-    input = raw_input
+    input = raw_input  # pylint: disable=invalid-name, redefined-builtin
 except NameError:
     pass
 


### PR DESCRIPTION
This pull request adds a bit of safety to the roamer:
* From now `roamer` will not take any action without explicit approval  
 Before command(s) execution user will be asked to confirm commands:  
**Please indicate approval: [y/N]** -- No is default behavior. From now user have to answer Yes, Y, yes or y or with any word which starts with `y` to confirm, or use anything else to deny.
* This behavior could be discarded by passing argument `--skip-approval`. The `roamer` will execute all the commands generated after exiting editor.
* Whilst the prompt is displayed -- pressing `Ctrl+C` will discard any command(s) and exits the `roamer`. 

Tested on `Debian 8`